### PR TITLE
✨ Feat: level 6 요구사항 구현

### DIFF
--- a/HarryPotterSeries/HarryPotterSeries.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HarryPotterSeries/HarryPotterSeries.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e3a06d09e540069f6ae8684d29f391fb861c138c4429e10e219ada53aa3aa5ee",
+  "originHash" : "fe9d3ecd9d2e9eb4c6093c1806b705e5effbbae419ee9e2e649e2fa8bb33c6f1",
   "pins" : [
     {
       "identity" : "combinecocoa",

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewController.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewController.swift
@@ -43,6 +43,13 @@ final class HomeViewController: UIViewController {
     
     // MARK: - Methods
     private func bindViewModel() {
+        viewModel.$books
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] books in
+                self?.homeView.setSeriesButtons(books: books)
+            }
+            .store(in: &cancellables)
+        
         viewModel.$selectedBook
             .receive(on: DispatchQueue.main)
             .sink { [weak self] book in

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewController.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewController.swift
@@ -38,7 +38,6 @@ final class HomeViewController: UIViewController {
         bindViewModel()
         bindView()
         viewModel.loadBooks()
-        viewModel.change()
     }
     
     // MARK: - Methods
@@ -88,6 +87,13 @@ final class HomeViewController: UIViewController {
         homeView.summaryView.expandButton.tapPublisher
             .sink { [weak self] in
                 self?.viewModel.toggleExpandButton()
+            }
+            .store(in: &cancellables)
+        
+        homeView.seriesButtonTapped
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] index in
+                self?.viewModel.isTappedSeriesButton(of: index)
             }
             .store(in: &cancellables)
     }

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewModel.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewModel.swift
@@ -30,15 +30,6 @@ final class HomeViewModel {
         isExpandedSummary = self.loadExpandState()
     }
     
-    // TODO: 다른 책 선택 확인용, 삭제 예정
-    func change() {
-        DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
-            guard let self else { return }
-            selectedBook = books[1]
-            updateSummaryInfo(for: selectedBook)
-        }
-    }
-    
     func loadBooks() {
         do {
             books = try fetchBookUseCase.execute()
@@ -72,5 +63,10 @@ final class HomeViewModel {
     
     func loadExpandState() -> Bool {
         UserDefaults.standard.bool(forKey: UserDefaultsKey.summaryExpandState)
+    }
+    
+    func isTappedSeriesButton(of index: Int) {
+        selectedBook = books[index]
+        updateSummaryInfo(for: selectedBook)
     }
 }

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewModel.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/HomeViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class HomeViewModel {
     private let fetchBookUseCase: FetchBooksUseCase
-    private var books: [Book] = []
+    @Published private(set) var books: [Book] = []
     @Published private(set) var selectedBook: Book!
     @Published private(set) var errorMessage: String?
     @Published private(set) var summaryText: String?

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/BookDescriptionView.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/BookDescriptionView.swift
@@ -21,7 +21,7 @@ final class BookDescriptionView: UIView {
     
     private let contentStackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = BookSpacing.labelToLabel
+        $0.spacing = BookSpacing.viewToView
         $0.alignment = .fill
         $0.distribution = .equalSpacing
     }
@@ -61,7 +61,7 @@ final class BookDescriptionView: UIView {
         }
         
         contentStackView.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(BookSpacing.labelToLabel)
+            make.top.equalTo(titleLabel.snp.bottom).offset(BookSpacing.viewToView)
             make.horizontalEdges.bottom.equalToSuperview()
         }
     }

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/HomeView.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/HomeView.swift
@@ -17,10 +17,11 @@ final class HomeView: UIView {
         $0.numberOfLines = 0
     }
     
-    private let seriesButton = UIButton().then {
-        $0.titleLabel?.font = .systemFont(ofSize: 16)
-        $0.backgroundColor = .systemBlue
-        $0.layer.cornerRadius = 20
+    let seriesButtonStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = BookSpacing.viewToView
+        $0.alignment = .center
+        $0.distribution = .equalSpacing
     }
     
     private let scrollView = UIScrollView().then {
@@ -55,7 +56,7 @@ final class HomeView: UIView {
     private func setupAddViews() {
         [
             titleLabel,
-            seriesButton,
+            seriesButtonStackView,
             scrollView
         ].forEach { addSubview($0) }
         
@@ -77,14 +78,13 @@ final class HomeView: UIView {
             make.horizontalEdges.equalToSuperview().inset(BookSpacing.horizontal)
         }
         
-        seriesButton.snp.makeConstraints { make in
+        seriesButtonStackView.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(16)
             make.centerX.equalToSuperview()
-            make.width.height.equalTo(40)
         }
         
         scrollView.snp.makeConstraints { make in
-            make.top.equalTo(seriesButton.snp.bottom).offset(BookSpacing.vertical)
+            make.top.equalTo(seriesButtonStackView.snp.bottom).offset(BookSpacing.vertical)
             make.horizontalEdges.bottom.equalToSuperview()
         }
         
@@ -96,7 +96,6 @@ final class HomeView: UIView {
     
     func configureView(with book: Book) {
         titleLabel.text = book.title
-        seriesButton.setTitle(String(book.seriesNumber!), for: .normal)
         bookInfoView.configureView(with: book)
         dedicationView.configureView(title: SectionTitle.dedication, contents: [book.dedication])
         chapterView.configureView(title: SectionTitle.chapter, contents: book.chapters.map { $0.title })
@@ -104,5 +103,25 @@ final class HomeView: UIView {
     
     func setSummary(with summary: String, isExpandable: Bool) {
         summaryView.configureView(title: SectionTitle.summary, contents: [summary], isExpandable)
+    }
+    
+    func setSeriesButtons(books: [Book]) {
+        books.forEach { book in
+            let button = makeSeriesButton(number: book.seriesNumber!)
+            seriesButtonStackView.addArrangedSubview(button)
+        }
+    }
+    
+    private func makeSeriesButton(number: Int) -> UIButton {
+        let button = UIButton().then {
+            $0.setTitle(String(number), for: .normal)
+            $0.titleLabel?.font = .systemFont(ofSize: 16)
+            $0.backgroundColor = .systemBlue
+            $0.layer.cornerRadius = 20
+        }
+        button.snp.makeConstraints { make in
+            make.width.height.equalTo(40)
+        }
+        return button
     }
 }

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/HomeView.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/HomeView.swift
@@ -104,6 +104,7 @@ final class HomeView: UIView {
     
     func configureView(with book: Book) {
         titleLabel.text = book.title
+        updateSeriesButtonStack(seriesNumber: book.seriesNumber!)
         bookInfoView.configureView(with: book)
         dedicationView.configureView(title: SectionTitle.dedication, contents: [book.dedication])
         chapterView.configureView(title: SectionTitle.chapter, contents: book.chapters.map { $0.title })
@@ -112,26 +113,45 @@ final class HomeView: UIView {
     func setSummary(with summary: String, isExpandable: Bool) {
         summaryView.configureView(title: SectionTitle.summary, contents: [summary], isExpandable)
     }
-    
+}
+
+// MARK: - Series Buttons
+extension HomeView {
     func setSeriesButtons(books: [Book]) {
         books.enumerated().forEach { index, book in
-            let button = makeSeriesButton(number: book.seriesNumber!)
+            let button = makeSeriesButton(of: book.seriesNumber!)
             seriesButtonStackView.addArrangedSubview(button)
             bindSeriesButtonTap(button, at: index)
         }
     }
     
-    private func makeSeriesButton(number: Int) -> UIButton {
-        let button = UIButton().then {
-            $0.setTitle(String(number), for: .normal)
-            $0.titleLabel?.font = .systemFont(ofSize: 16)
-            $0.backgroundColor = .systemBlue
-            $0.layer.cornerRadius = 20
-        }
+    private func makeSeriesButton(of seriesNumber: Int) -> UIButton {
+        let config = makeButtonConfiguration(title: String(seriesNumber))
+        let button = UIButton(configuration: config)
+        applySelectedStyle(for: button)
+        
         button.snp.makeConstraints { make in
             make.width.height.equalTo(40)
         }
         return button
+    }
+    
+    private func makeButtonConfiguration(title: String) -> UIButton.Configuration {
+        var config = UIButton.Configuration.filled()
+        config.title = title
+        config.baseBackgroundColor = .systemGray6
+        config.baseForegroundColor = .systemBlue
+        config.cornerStyle = .capsule
+        return config
+    }
+    
+    private func applySelectedStyle(for button: UIButton) {
+        button.configurationUpdateHandler = { button in
+            var updated = button.configuration
+            updated?.baseBackgroundColor = button.isSelected ? .systemBlue : .systemGray6
+            updated?.baseForegroundColor = button.isSelected ? .white : .systemBlue
+            button.configuration = updated
+        }
     }
     
     private func bindSeriesButtonTap(_ button: UIButton, at index: Int) {
@@ -140,5 +160,12 @@ final class HomeView: UIView {
                 self?.seriesButtonTapped.send(index)
             }
             .store(in: &cancellables)
+    }
+    
+    private func updateSeriesButtonStack(seriesNumber: Int) {
+        seriesButtonStackView.subviews.enumerated().forEach { index, view in
+            let button = view as! UIButton
+            button.isSelected = index == seriesNumber - 1
+        }
     }
 }

--- a/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/HomeView.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Presentation/Home/Views/HomeView.swift
@@ -5,12 +5,20 @@
 //  Created by 곽다은 on 3/28/25.
 //
 
+import Combine
 import UIKit
 import SnapKit
 import Then
 
 final class HomeView: UIView {
+    
+    // MARK: - Event Properties
+    
+    let seriesButtonTapped = PassthroughSubject<Int, Never>()
+    var cancellables = [AnyCancellable]()
+    
     // MARK: - Components
+    
     private let titleLabel = UILabel().then {
         $0.textAlignment = .center
         $0.font = .boldSystemFont(ofSize: 24)
@@ -106,9 +114,10 @@ final class HomeView: UIView {
     }
     
     func setSeriesButtons(books: [Book]) {
-        books.forEach { book in
+        books.enumerated().forEach { index, book in
             let button = makeSeriesButton(number: book.seriesNumber!)
             seriesButtonStackView.addArrangedSubview(button)
+            bindSeriesButtonTap(button, at: index)
         }
     }
     
@@ -123,5 +132,13 @@ final class HomeView: UIView {
             make.width.height.equalTo(40)
         }
         return button
+    }
+    
+    private func bindSeriesButtonTap(_ button: UIButton, at index: Int) {
+        button.tapPublisher
+            .sink { [weak self] in
+                self?.seriesButtonTapped.send(index)
+            }
+            .store(in: &cancellables)
     }
 }

--- a/HarryPotterSeries/HarryPotterSeries/Support/Constants/Constants.swift
+++ b/HarryPotterSeries/HarryPotterSeries/Support/Constants/Constants.swift
@@ -41,7 +41,7 @@ enum ButtonTitle {
 enum BookSpacing {
     static let horizontal: CGFloat = 20
     static let vertical: CGFloat = 24
-    static let labelToLabel: CGFloat = 8
+    static let viewToView: CGFloat = 8
 }
 
 enum BookFontSize {


### PR DESCRIPTION
- 기존의 시리즈 버튼에 시리즈 스택뷰로 변경

**이벤트 처리 로직**
1. 각 버튼을 탭하면 `passThroughSubject`인 `seriesButtonTapped`로 해당 버튼의 스택뷰 상 인덱스 값을 방출
2. `homeView`에서 이 `subject`를 구독해서 방출된 값을 `viewModel`의 `seriesButtonTapped(of:)` 메서드의 인자로 하여 호출
3. 인덱스를 기반으로 `books` 배열에서 선택된 책을 찾고 `selectedBook`에 할당, summary 관련 업데이트(더보기 버튼이 있어야 하는지 등)
